### PR TITLE
[Go] Add Load Balancer

### DIFF
--- a/KT/LOAD_BALANCER.md
+++ b/KT/LOAD_BALANCER.md
@@ -1,0 +1,116 @@
+# Stock-to-Server Load Balancer
+
+## Architecture
+
+The load balancer uses explicit stock→server mapping to distribute trading load based on trading frequency and volume.
+
+### Current Setup (Example)
+
+**Servers:** 4 engine instances
+- Server 0 (`:6060`): High-frequency stocks (NVDA)
+- Server 1 (`:6061`): High-frequency stocks (AAPL)
+- Server 2 (`:6062`): Medium-frequency stocks (TSLA, MSFT)
+- Server 3 (`:6063`): High-frequency stocks (GOOGL)
+
+**Configuration:** `backend/config/stock_mapping.json`
+
+```json
+{
+  "NVDA": 0,
+  "AAPL": 1,
+  "TSLA": 2,
+  "MSFT": 2,
+  "GOOGL": 3
+}
+```
+
+## How It Works
+
+1. **Explicit Mapping (Primary):** `pickServer()` first checks the `stock_mapping.json` file for exact symbol match
+2. **Hash Fallback:** If symbol not in mapping, uses FNV-1a hash for deterministic routing
+3. **O(1) Performance:** Map lookup or single hash operation per request
+
+## Scaling to 500+ Stocks
+
+### Option 1: Manual Mapping (Best Control)
+Analyze trading data and manually assign stocks to servers:
+
+```bash
+# Generate even distribution as starting point
+cd backend
+go run scripts/generate_mapping.go \
+  --symbols symbols.txt \
+  --servers 50 \
+  --output config/stock_mapping.json
+```
+
+Then adjust high-frequency stocks manually based on real data.
+
+### Option 2: Auto-Balance Script
+Use the `BuildEvenMapping()` helper in code:
+
+```go
+symbols := []string{"NVDA", "AAPL", "TSLA", /* ... 500 more ... */}
+mapping := loadbalancer.BuildEvenMapping(symbols, 50) // 50 servers
+loadbalancer.SaveMapping("config/stock_mapping.json", mapping)
+```
+
+### Option 3: Dynamic Rebalancing
+Monitor per-server request rates and periodically regenerate mapping:
+- Track requests/sec per stock
+- Group stocks by trading frequency
+- Distribute groups evenly across servers
+- Hot-reload mapping (requires adding `Balancer.UpdateMapping()`)
+
+## Testing
+
+Start 4 mock engine servers:
+```bash
+for port in 6060 6061 6062 6063; do
+  echo "Starting mock engine on :$port"
+  python3 -c "
+from http.server import BaseHTTPRequestHandler, HTTPServer
+class H(BaseHTTPRequestHandler):
+    def do_POST(self):
+        l = int(self.headers.get('Content-Length',0))
+        body = self.rfile.read(l).decode()
+        print(f'[{$port}] {self.path} -> {body}')
+        self.send_response(200); self.end_headers(); self.wfile.write(b'ok')
+HTTPServer(('0.0.0.0', $port), H).serve_forever()
+" &
+done
+```
+
+Test with grpcurl:
+```bash
+# NVDA should go to server 0 (6060)
+grpcurl -plaintext -d '{"tradetype":"GTILLCANCEL","side":"BUY","name":"NVDA","price":100,"quantity":1}' \
+  localhost:50051 orderbook.OrderService/Trade
+
+# TSLA should go to server 2 (6062)
+grpcurl -plaintext -d '{"tradetype":"GTILLCANCEL","side":"BUY","name":"TSLA","price":200,"quantity":5}' \
+  localhost:50051 orderbook.OrderService/Trade
+
+# Unknown stock falls back to hash-based routing
+grpcurl -plaintext -d '{"tradetype":"GTILLCANCEL","side":"BUY","name":"UNKNOWN","price":50,"quantity":2}' \
+  localhost:50051 orderbook.OrderService/Trade
+```
+
+## Modifying Mapping
+
+Edit `backend/config/stock_mapping.json` and restart the gRPC server. Changes take effect immediately on restart.
+
+For production, implement hot-reload:
+```go
+// Add to Balancer
+func (b *Balancer) UpdateMapping(mapping map[string]int) {
+    // Use atomic.Value or sync.RWMutex for thread-safe updates
+}
+```
+
+## Performance Notes
+
+- **Mapping lookup:** O(1) map access (~10-20ns)
+- **Hash fallback:** O(1) FNV-1a hash (~50ns)
+- **No blocking:** Fire-and-forget keeps latency <2μs
+- **Connection pooling:** 200 idle connections per server for reuse

--- a/KT/README_GRPC.md
+++ b/KT/README_GRPC.md
@@ -1,6 +1,5 @@
 # gRPC Migration Summary
 
-## ✅ Migration Complete!
 
 Your Trading Engine has been successfully migrated from HTTP/JSON to gRPC. All build dependencies have been installed and resolved.
 

--- a/backend/cmd/api/main.go
+++ b/backend/cmd/api/main.go
@@ -8,6 +8,7 @@ import (
 	"syscall"
 
 	"github.com/TanishqM1/Orderbook/internal/handlers"
+	"github.com/TanishqM1/Orderbook/internal/loadbalancer"
 	pb "github.com/TanishqM1/Orderbook/internal/pb"
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
@@ -25,11 +26,34 @@ func main() {
 		log.Fatalf("Failed to listen on port 50051: %v", err)
 	}
 
+	// Initialize load balancer with engine servers
+	engineServers := []string{
+		"http://localhost:6060", // Server 0: NVDA
+		"http://localhost:6061", // Server 1: AAPL
+		"http://localhost:6062", // Server 2: TSLA, MSFT
+		"http://localhost:6063", // Server 3: GOOGL
+	}
+
+	// Load stock-to-server mapping from config file
+	mappingPath := "../../config/stock_mapping.json"
+	var balancer *loadbalancer.Balancer
+
+	if mapping, err := loadbalancer.LoadMapping(mappingPath); err == nil {
+		balancer = loadbalancer.NewWithMapping(engineServers, mapping)
+		log.Infof("Load balancer initialized with %d servers and %d explicit stock mappings",
+			len(engineServers), len(mapping))
+	} else {
+		// Fallback to hash-based routing if mapping file not found
+		balancer = loadbalancer.New(engineServers)
+		log.Warnf("Stock mapping file not found (%s), using hash-based routing: %v", mappingPath, err)
+		log.Infof("Load balancer initialized with %d servers (hash-based routing)", len(engineServers))
+	}
+
 	// Create gRPC server
 	grpcServer := grpc.NewServer()
 
-	// Register our service
-	pb.RegisterOrderServiceServer(grpcServer, handlers.NewGRPCServer())
+	// Register our service with load balancer
+	pb.RegisterOrderServiceServer(grpcServer, handlers.NewGRPCServer(balancer))
 
 	// Register reflection service (useful for tools like grpcurl)
 	reflection.Register(grpcServer)

--- a/backend/config/stock_mapping.json
+++ b/backend/config/stock_mapping.json
@@ -1,0 +1,7 @@
+{
+  "NVDA": 0,
+  "AAPL": 1,
+  "TSLA": 2,
+  "MSFT": 2,
+  "GOOGL": 3
+}

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -3,7 +3,6 @@ module github.com/TanishqM1/Orderbook
 go 1.25.2
 
 require (
-	github.com/go-chi/chi v1.5.5
 	github.com/sirupsen/logrus v1.9.3
 	google.golang.org/grpc v1.78.0
 	google.golang.org/protobuf v1.36.11

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -1,8 +1,6 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/go-chi/chi v1.5.5 h1:vOB/HbEMt9QqBqErz07QehcOKHaWFtuj87tTDVz2qXE=
-github.com/go-chi/chi v1.5.5/go.mod h1:C9JqLr3tIYjDOZpzn+BCuxY8z8vmca43EeMgyZt7irw=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=

--- a/backend/internal/handlers/grpc_server.go
+++ b/backend/internal/handlers/grpc_server.go
@@ -1,15 +1,19 @@
 package handlers
 
 import (
+	"github.com/TanishqM1/Orderbook/internal/loadbalancer"
 	pb "github.com/TanishqM1/Orderbook/internal/pb"
 )
 
 // GRPCServer implements the OrderService gRPC server
 type GRPCServer struct {
 	pb.UnimplementedOrderServiceServer
+	balancer *loadbalancer.Balancer
 }
 
 // NewGRPCServer creates a new gRPC server instance
-func NewGRPCServer() *GRPCServer {
-	return &GRPCServer{}
+func NewGRPCServer(balancer *loadbalancer.Balancer) *GRPCServer {
+	return &GRPCServer{
+		balancer: balancer,
+	}
 }

--- a/backend/internal/handlers/grpc_trade.go
+++ b/backend/internal/handlers/grpc_trade.go
@@ -2,11 +2,8 @@ package handlers
 
 import (
 	"context"
-	"io"
-	"net/http"
 	"net/url"
 	"strconv"
-	"strings"
 
 	"github.com/TanishqM1/Orderbook/api"
 	pb "github.com/TanishqM1/Orderbook/internal/pb"
@@ -15,11 +12,11 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-// Trade handles the gRPC Trade request
+// Trade handles the gRPC Trade request with minimal latency
+// Critical path: validate -> generate ID -> fire request -> return
+// Logging happens in background after request is already in flight
 func (s *GRPCServer) Trade(ctx context.Context, req *pb.TradeRequest) (*pb.TradeResponse, error) {
-	log.Debugf("Received Trade request: %+v", req)
-
-	// Validate request
+	// Fast validation (only required fields, no expensive checks)
 	if req.Tradetype == "" || req.Side == "" || req.Name == "" {
 		return nil, status.Errorf(codes.InvalidArgument, "tradetype, side, and name fields are required")
 	}
@@ -27,52 +24,31 @@ func (s *GRPCServer) Trade(ctx context.Context, req *pb.TradeRequest) (*pb.Trade
 		return nil, status.Errorf(codes.InvalidArgument, "price and quantity must be positive")
 	}
 
-	// Generate order ID
+	// Generate order ID (atomic increment - ~nanoseconds)
 	orderId := api.GetNextOrderId()
 
-	// Prepare request to C++ engine
-	urlValues := url.Values{}
-	urlValues.Set("orderid", strconv.FormatUint(orderId, 10))
-	urlValues.Set("tradetype", req.Tradetype)
-	urlValues.Set("side", req.Side)
-	urlValues.Set("price", strconv.Itoa(int(req.Price)))
-	urlValues.Set("quantity", strconv.Itoa(int(req.Quantity)))
-	urlValues.Set("book", req.Name)
+	// Build form data (minimal allocations)
+	form := url.Values{}
+	form.Set("orderid", strconv.FormatUint(orderId, 10))
+	form.Set("tradetype", req.Tradetype)
+	form.Set("side", req.Side)
+	form.Set("price", strconv.Itoa(int(req.Price)))
+	form.Set("quantity", strconv.Itoa(int(req.Quantity)))
+	form.Set("book", req.Name)
 
-	reqBody := strings.NewReader(urlValues.Encode())
-	client := http.Client{}
-	cppServerURL := "http://localhost:6060/trade"
+	// FIRE REQUEST IMMEDIATELY (non-blocking, request already in flight)
+	s.balancer.FireTrade(form)
 
-	log.Debugf("Forwarding trade request to C++ engine: %s with body: %s", cppServerURL, urlValues.Encode())
+	// Log in background (after request is already sent)
+	go func() {
+		log.Infof("Trade order fired: ID=%d book=%s side=%s type=%s price=%d qty=%d",
+			orderId, req.Name, req.Side, req.Tradetype, req.Price, req.Quantity)
+	}()
 
-	// Create HTTP request to C++ engine
-	httpReq, err := http.NewRequestWithContext(ctx, "POST", cppServerURL, reqBody)
-	if err != nil {
-		log.Errorf("Failed to create C++ request: %v", err)
-		return nil, status.Errorf(codes.Internal, "failed to create request to C++ engine")
-	}
-	httpReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-
-	// Send request to C++ engine
-	cppResp, err := client.Do(httpReq)
-	if err != nil {
-		log.Errorf("Failed to connect to C++ engine at :6060. Is the C++ server running? Error: %v", err)
-		return nil, status.Errorf(codes.Unavailable, "failed to connect to C++ engine: %v", err)
-	}
-	defer cppResp.Body.Close()
-
-	// Read response body
-	respBody, err := io.ReadAll(cppResp.Body)
-	if err != nil {
-		log.Errorf("Failed to read response body: %v", err)
-		return nil, status.Errorf(codes.Internal, "failed to read C++ engine response")
-	}
-
-	log.Infof("Processed new order with ID: %d", orderId)
-
+	// Return success immediately
 	return &pb.TradeResponse{
 		OrderId:    orderId,
-		StatusCode: int32(cppResp.StatusCode),
-		Body:       string(respBody),
+		StatusCode: 202, // HTTP 202 Accepted
+		Body:       "Order queued",
 	}, nil
 }

--- a/backend/internal/loadbalancer/balancer.go
+++ b/backend/internal/loadbalancer/balancer.go
@@ -1,0 +1,165 @@
+package loadbalancer
+
+import (
+	"encoding/json"
+	"hash/fnv"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+)
+
+// Balancer routes requests to engine servers with minimal overhead
+type Balancer struct {
+	servers []string
+	client  *http.Client
+	mapping map[string]int // explicit stock symbol -> server index mapping
+}
+
+// New creates a balancer with an optimized HTTP client for minimal latency
+func New(servers []string) *Balancer {
+	// Tuned transport for maximum throughput and connection reuse
+	tr := &http.Transport{
+		DialContext: (&net.Dialer{
+			Timeout:   50 * time.Millisecond,
+			KeepAlive: 30 * time.Second,
+		}).DialContext,
+		MaxIdleConns:          1000,
+		MaxIdleConnsPerHost:   200,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+		DisableCompression:    true, // avoid decompression overhead
+	}
+
+	return &Balancer{
+		servers: servers,
+		client: &http.Client{
+			Transport: tr,
+			Timeout:   5 * time.Second,
+		},
+	}
+}
+
+// NewWithMapping creates a balancer with explicit stock-to-server mapping
+func NewWithMapping(servers []string, mapping map[string]int) *Balancer {
+	b := New(servers)
+	b.mapping = mapping
+	return b
+}
+
+// LoadMapping reads stock-to-server mapping from a JSON file
+// Expected format: {"NVDA": 0, "AAPL": 1, "TSLA": 2, ...}
+func LoadMapping(path string) (map[string]int, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var mapping map[string]int
+	if err := json.Unmarshal(data, &mapping); err != nil {
+		return nil, err
+	}
+
+	return mapping, nil
+}
+
+// SaveMapping writes stock-to-server mapping to a JSON file
+func SaveMapping(path string, mapping map[string]int) error {
+	data, err := json.MarshalIndent(mapping, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0644)
+}
+
+// BuildEvenMapping creates a balanced distribution of symbols across servers
+// Uses round-robin assignment to distribute load evenly
+func BuildEvenMapping(symbols []string, numServers int) map[string]int {
+	mapping := make(map[string]int, len(symbols))
+	for i, symbol := range symbols {
+		mapping[symbol] = i % numServers
+	}
+	return mapping
+}
+
+// pickServer returns server index for a stock symbol
+// First checks explicit mapping, then falls back to FNV1a hash
+// This is O(1) - map lookup or hash + modulo
+func (b *Balancer) pickServer(book string) int {
+	if len(b.servers) == 0 {
+		return -1
+	}
+
+	// Check explicit mapping first
+	if b.mapping != nil {
+		if idx, ok := b.mapping[book]; ok {
+			if idx >= 0 && idx < len(b.servers) {
+				return idx
+			}
+		}
+	}
+
+	// Fallback to hash-based routing
+	h := fnv.New32a()
+	h.Write([]byte(book))
+	return int(h.Sum32()) % len(b.servers)
+}
+
+// FireTrade sends trade request to engine without waiting for response
+// This is fire-and-forget for maximum speed - request is in flight immediately
+func (b *Balancer) FireTrade(form url.Values) {
+	book := form.Get("book")
+	idx := b.pickServer(book)
+	if idx < 0 {
+		return // no servers available
+	}
+
+	target := b.servers[idx] + "/trade"
+
+	// Fire in goroutine so we don't block at all
+	go func() {
+		req, err := http.NewRequest("POST", target, strings.NewReader(form.Encode()))
+		if err != nil {
+			return
+		}
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+		resp, err := b.client.Do(req)
+		if err != nil {
+			return
+		}
+		resp.Body.Close() // close immediately, don't read
+	}()
+}
+
+// ForwardStatus sends status request and waits for response (synchronous)
+func (b *Balancer) ForwardStatus() (*http.Response, error) {
+	// For status, just hit first server (or implement round-robin if needed)
+	if len(b.servers) == 0 {
+		return nil, http.ErrServerClosed
+	}
+
+	target := b.servers[0] + "/status"
+	return b.client.Get(target)
+}
+
+// ForwardCancel sends cancel request and waits for response
+func (b *Balancer) ForwardCancel(form url.Values) (*http.Response, error) {
+	book := form.Get("name")
+	idx := b.pickServer(book)
+	if idx < 0 {
+		return nil, http.ErrServerClosed
+	}
+
+	target := b.servers[idx] + "/cancel"
+	req, err := http.NewRequest("POST", target, strings.NewReader(form.Encode()))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	return b.client.Do(req)
+}

--- a/compile.txt
+++ b/compile.txt
@@ -1,29 +1,38 @@
-cd /S/Users/tanis/Desktop/Projects/OrderBook/backend/engine
+Only the Go architecutre can be tested so far (on develop)
+
+# start mock ports with current JSON config (subject to change)
+
+for port in 6060 6061 6062 6063; do
+  python3 -c "
+from http.server import BaseHTTPRequestHandler, HTTPServer
+class H(BaseHTTPRequestHandler):
+    def do_POST(self):
+        l = int(self.headers.get('Content-Length',0))
+        b = self.rfile.read(l).decode()
+        print('[${port}] POST', self.path, '->', b)
+        self.send_response(200); self.end_headers(); self.wfile.write(b'ok')
+HTTPServer(('0.0.0.0', ${port}), H).serve_forever()
+" &
+done
 
 
+# run go server
 
-1. compile and link server
-# Windows:
-# g++ -std=c++23 -O2 Server.cpp -lws2_32 -o server.exe
-# macOS/Linux (no extra libs needed):
-g++ -std=c++23 -O2 Server.cpp -o server
+# Stop the current server (Ctrl+C if running)
+# Then restart:
+cd /Users/tanishq/Work/TradingEngine/backend/cmd/api
+go run .
 
-./server.exe
+# send mock requests. a success message should be logged
 
+# NVDA → should now hit port 6060 (index 0)
+grpcurl -plaintext -d '{"tradetype":"GTILLCANCEL","side":"BUY","name":"NVDA","price":100,"quantity":1}' \
+  localhost:50051 orderbook.OrderService/Trade
 
-**NEW TERMINAL**
+# TSLA → should hit port 6062 (index 2)
+grpcurl -plaintext -d '{"tradetype":"GTILLCANCEL","side":"BUY","name":"TSLA","price":200,"quantity":5}' \
+  localhost:50051 orderbook.OrderService/Trade
 
-cd /S/Users/tanis/Desktop/Projects/OrderBook/backend/cmd/api
-go run main.go
-
-# This example will result in the C++ server assigning a unique ID (1)
-curl -X POST http://localhost:8000/order/trade -H "Content-Type: application/json" -d '{
-    "tradetype": "GTC",
-    "side": "BUY",
-    "price": 100,
-    "quantity": 10,
-    "name": "GOOG"
-}'
-
-# This example will result in the C++ server cancelling (removing) the order if it's present in the orderbook.
-curl -X POST http://localhost:8000/order/cancel -H "Content-Type: application/json" -d '{"orderid": 1}'
+# MSFT → should also hit port 6062 (index 2, shares with TSLA)
+grpcurl -plaintext -d '{"tradetype":"GTILLCANCEL","side":"BUY","name":"MSFT","price":150,"quantity":3}' \
+  localhost:50051 orderbook.OrderService/Trade


### PR DESCRIPTION
- Removed the old chi router that would get incoming JSON requests, send it to the backend, but WAIT for a response before logging and sends the https response.

- Now we have a "fire and forget" strategy where requests are instantly propogated to the engine and "order placed" is returned.

- Added a JSON file to map Stock Symbol -> ports (that the engine is running on). not sure if this is too slow / will cause a bottleneck, we can experiment later.

- We also have 200 keep-alive connections running per host if a huge load of requests come it at the same time for some reason (this is probably overkill, but I don't think there is much CPU overhead that it really matters).

- because everything runs on localhost the timeout is 1s but realistically this is literally impossible to reach